### PR TITLE
Fixing type for rowClassName prop

### DIFF
--- a/src/components/datatable/DataTable.d.ts
+++ b/src/components/datatable/DataTable.d.ts
@@ -50,7 +50,7 @@ interface DataTableProps {
     exportFilename?: string;
     contextMenu?: any;
     rowGroupMode?: string;
-    rowClassName?(): void;
+    rowClassName?(rowData: any): object;
     rowGroupHeaderTemplate?(): void;
     rowGroupFooterTemplate?(): void;
     onColumnResizeEnd?(element: any, delta: number): void;


### PR DESCRIPTION
rowClassName prop should be typed as a function taking a parameter rowData: any and returning an object